### PR TITLE
Update Readme with CropperJS-Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ View in action at https://harryy2510.github.io/ngx-img
 
 ## Dependencies
 * [Angular](https://angular.io) (*requires* Angular 4 or higher, tested with 4.4.6)
+* [CropperJS](https://github.com/fengyuanchen/cropperjs) (required for cropping)
 
 ## Installation
 Install above dependencies via *npm*. 


### PR DESCRIPTION
When installing and using it the first time, it didn't work, because it couldn't resolve `cropperjs`. 
The fix for me was to `npm i -s cropperjs`. 