### PR TITLE
improvement: add capability to pass fillColor option

### DIFF
--- a/projects/ngx-img/src/module/component/ngx-img-crop.component.ts
+++ b/projects/ngx-img/src/module/component/ngx-img-crop.component.ts
@@ -77,6 +77,9 @@ export class NgxImgCropComponent implements OnInit, OnDestroy {
         if (opt.maxHeight) {
           options.maxHeight = opt.maxHeight;
         }
+        if (opt.fillColor) {
+          options.fillColor = opt.fillColor;
+        }
         this.cropper[i] = new Cropper(el, {
           aspectRatio: opt.ratio,
           viewMode: opt.viewMode || 0,


### PR DESCRIPTION
Currently when we crop image, setting cropping box outside of that image, the void space is filled with black background.

Cropperjs already have fillColor option which we can pass to getCroppedCanvas to indicate what color to use for filling the void space.

[https://github.com/fengyuanchen/cropper/issues/776#issuecomment-318803227](https://github.com/fengyuanchen/cropper/issues/776#issuecomment-318803227)

Please review this PR! Thanks.