### PR TITLE
feat(img-service): support blob output

### DIFF
--- a/projects/ngx-img/src/module/component/ngx-img.component.ts
+++ b/projects/ngx-img/src/module/component/ngx-img.component.ts
@@ -32,7 +32,8 @@ export class NgxImgComponent implements OnInit, OnDestroy, OnChanges {
     fileType?: string[],
     height?: number,
     quality?: number,
-    crop?: any
+    crop?: any,
+    output?: 'base64' | 'blob'
   };
   @Input() errorTexts: {
     fileSize?: string,
@@ -65,7 +66,8 @@ export class NgxImgComponent implements OnInit, OnDestroy, OnChanges {
     fileType?: string[],
     height?: number,
     quality?: number,
-    crop?: any
+    crop?: any,
+    output?: 'blob' | 'base64'
   } = {
     fileSize: 2048,
     minWidth: 0,
@@ -73,7 +75,8 @@ export class NgxImgComponent implements OnInit, OnDestroy, OnChanges {
     minHeight: 0,
     maxHeight: 0,
     fileType: ['.gif', '.jpeg', '.png', '.jpg'],
-    quality: 0.8
+    quality: 0.8,
+    output: 'base64'
   };
   _text: {
     default?: string,

--- a/projects/ngx-img/src/module/service/ngx-img.service.ts
+++ b/projects/ngx-img/src/module/service/ngx-img.service.ts
@@ -69,7 +69,11 @@ export class NgxImgService {
           Math.floor(destHeight)
         );
         ctx.restore();
-        resolve(cvs.toDataURL(mimeType, config.quality));
+        if (config.output === 'blob') {
+          cvs.toBlob(resolve, mimeType, config.quality);
+        } else {
+          resolve(cvs.toDataURL(mimeType, config.quality));
+        }
       };
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,6 +35,7 @@ export class AppComponent implements OnInit {
         maxHeight: 0,  // maximum height of image to be exported (by default 0, signifies any height)
         width: 0,  // width of image to be exported (by default 0, signifies any width)
         height: 0,  // height of image to be exported (by default 0, signifies any height)
+        output: 'base64',  // Output format. Can be 'base64' or 'blob'. (by default 'base64')
       }
     ]
   }`;


### PR DESCRIPTION
Add Blob output support.
Useful when the image needs to be uploaded to a bucket